### PR TITLE
feat: Add manual lease release method

### DIFF
--- a/src/lease.rs
+++ b/src/lease.rs
@@ -35,7 +35,7 @@ impl Lease {
         self
     }
 
-    /// Asynchronously releases the underlying lock.
+    /// Releases the lease returning `Ok(())` after successful deletion.
     ///
     /// Note: The local guard is unlocked **first** before deleting the lease.
     /// This avoids other concurrent acquires in the same process being unfairly

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -13,6 +13,7 @@ pub struct Lease {
     key_lease_v: Arc<(String, Mutex<Uuid>)>,
     /// A local guard to avoid db contention for leases within the same client.
     local_guard: Option<OwnedMutexGuard<()>>,
+    is_dropped: bool,
 }
 
 impl Lease {
@@ -21,6 +22,7 @@ impl Lease {
             client,
             key_lease_v: Arc::new((key, Mutex::new(lease_v))),
             local_guard: None,
+            is_dropped: false,
         };
 
         start_periodicly_extending(&lease);
@@ -31,6 +33,23 @@ impl Lease {
     pub(crate) fn with_local_guard(mut self, guard: OwnedMutexGuard<()>) -> Self {
         self.local_guard = Some(guard);
         self
+    }
+
+    /// Asynchronously releases the underlying lock.
+    pub async fn release(&mut self) {
+        let client = self.client.clone();
+        let key_lease_v = self.key_lease_v.clone();
+
+        // Drop local guard *before* deleting lease to avoid unfair local acquire advantage.
+        // Dropping the local_guard after deleting would be more efficient however during
+        // contention that efficiency could starve remote attempts to acquire the lease.
+        drop(self.local_guard.take());
+        client.try_clean_local_lock(key_lease_v.0.clone());
+
+        let lease_v = key_lease_v.1.lock().await;
+        let key = key_lease_v.0.clone();
+        // TODO retries, logs?
+        let _ = client.delete_lease(key, *lease_v).await;
     }
 }
 
@@ -60,20 +79,19 @@ fn start_periodicly_extending(lease: &Lease) {
 impl Drop for Lease {
     /// Asynchronously releases the underlying lock.
     fn drop(&mut self) {
-        let client = self.client.clone();
-        let key_lease_v = self.key_lease_v.clone();
-
-        // Drop local guard *before* deleting lease to avoid unfair local acquire advantage.
-        // Dropping the local_guard after deleting would be more efficient however during
-        // contention that efficiency could starve remote attempts to acquire the lease.
-        drop(self.local_guard.take());
-        client.try_clean_local_lock(key_lease_v.0.clone());
-
+        if self.is_dropped {
+            return;
+        }
+        self.is_dropped = true;
+        // Clone necessary data before moving self into the spawned task
+        let mut lease = Lease {
+            client: self.client.clone(),
+            key_lease_v: self.key_lease_v.clone(),
+            local_guard: self.local_guard.take(), // Take ownership of the guard
+            is_dropped: self.is_dropped,
+        };
         tokio::spawn(async move {
-            let lease_v = key_lease_v.1.lock().await;
-            let key = key_lease_v.0.clone();
-            // TODO retries, logs?
-            let _ = client.delete_lease(key, *lease_v).await;
+            lease.release().await;
         });
     }
 }

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -36,7 +36,7 @@ impl Lease {
     }
 
     /// Asynchronously releases the underlying lock.
-    pub async fn release(&mut self) {
+    pub async fn release(mut self) {
         let client = self.client.clone();
         let key_lease_v = self.key_lease_v.clone();
 
@@ -84,7 +84,7 @@ impl Drop for Lease {
         }
         self.is_dropped = true;
         // Clone necessary data before moving self into the spawned task
-        let mut lease = Lease {
+        let lease = Lease {
             client: self.client.clone(),
             key_lease_v: self.key_lease_v.clone(),
             local_guard: self.local_guard.take(), // Take ownership of the guard


### PR DESCRIPTION
Introduce a public `async fn release(&mut self)` method to the `Lease` struct. This allows users to explicitly release the underlying distributed lock before the `Lease` object goes out of scope.

The `Drop` implementation has been updated to call this new `release` method within a `tokio::spawn` block, preserving the existing asynchronous release behavior on drop while reusing the core release logic. This change provides finer-grained control over the lease lifecycle for scenarios where deterministic release timing is required.