### PR TITLE
feat: Add lease replacement and testcontainers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -12,20 +12,13 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-    - run: rustup update stable
-    - uses: actions/checkout@v4
-    - name: Setup dynamodb-local
-      uses: rrainn/dynamodb-action@v2.0.1
-      with:
-        port: 8000
-        cors: '*'
-    - run: mkdir ~/.aws && echo -e "[default]\nregion = eu-west-1" > ~/.aws/config
-    - run: echo -e "[default]\naws_access_key_id=12341234\naws_secret_access_key=12341234" > ~/.aws/credentials
-    - run: cargo test
+      - run: rustup update stable
+      - uses: actions/checkout@v4
+      - run: cargo test
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-    - run: rustup update stable
-    - uses: actions/checkout@v4
-    - run: cargo fmt -- --check
+      - run: rustup update stable
+      - uses: actions/checkout@v4
+      - run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.57"
-aws-sdk-dynamodb = { version = "1.1", default-features = false, features = ["rt-tokio"] }
+aws-sdk-dynamodb = { version = "1.1", default-features = false, features = [
+    "rt-tokio",
+] }
 aws-smithy-runtime-api = "1.0.1"
 time = "0.3.9"
 tokio = { version = "1.18", features = ["macros"] }
@@ -20,6 +22,8 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 aws-config = "1"
+testcontainers-modules = { version = "0.11.6", features = ["dynamodb"] }
+tokio = { version = "1", features = ["sync"] }
 
 [features]
 default = ["rustls"]

--- a/scripts/init-test.sh
+++ b/scripts/init-test.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-## Sets up dynamodb using docker (if ports are not already occupied).
-
-set -eu
-
-if ! nc -z localhost 8000; then
-  echo 'starting docker dynamodb-local on port 8000' >&2
-  docker run --rm -d -p 8000:8000 amazon/dynamodb-local
-fi

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,7 +8,6 @@ pub struct ClientBuilder {
     lease_ttl_seconds: u32,
     extend_period: Option<Duration>,
     acquire_cooldown: Duration,
-    grace_period: Duration,
 }
 
 impl Default for ClientBuilder {
@@ -18,7 +17,6 @@ impl Default for ClientBuilder {
             lease_ttl_seconds: 60,
             extend_period: None,
             acquire_cooldown: Duration::from_secs(1),
-            grace_period: Duration::from_secs(60), // Default grace period
         }
     }
 }
@@ -88,18 +86,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Sets the grace period after a lease expires before it can be forcefully acquired
-    /// by [`Client::acquire_or_replace_expired_lease`].
-    ///
-    /// This gives the original lease holder extra time to renew the lease if they were
-    /// slightly delayed.
-    ///
-    /// Default `60s`.
-    pub fn grace_period(mut self, grace_period: Duration) -> Self {
-        self.grace_period = grace_period;
-        self
-    }
-
     /// Builds a [`Client`].
     /// Does not check if the table exists or has the correct schema, see [`ClientBuilder::build_and_check_db`].
     ///
@@ -120,7 +106,6 @@ impl ClientBuilder {
             lease_ttl_seconds: self.lease_ttl_seconds,
             extend_period,
             acquire_cooldown: self.acquire_cooldown,
-            grace_period: self.grace_period, // Pass grace period
             local_locks: <_>::default(),
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -227,7 +227,10 @@ impl Client {
                         }
                         None => {
                             // Version missing: Check expiry (no grace) and delete based on expiry
-                            tracing::warn!(key = key, "Lease item missing '{LEASE_VERSION_FIELD}' field, attempting expiry-based replacement (backward compatibility)");
+                            tracing::warn!(
+                                key = key,
+                                "Lease item missing '{LEASE_VERSION_FIELD}' field, attempting expiry-based replacement (backward compatibility)"
+                            );
                             if now_ts >= expiry_ts {
                                 // Lease is expired (no grace period applied), try conditional delete on expiry
                                 let delete_result = self

--- a/src/client.rs
+++ b/src/client.rs
@@ -50,7 +50,6 @@ impl Client {
     /// If this lease has already been acquired elsewhere `Ok(None)` is returned.
     ///
     /// If a lease exists but has expired, it will be replaced and `Ok(Some(lease))` returned.
-    /// If an active (non-expired) lease exists elsewhere, `Ok(None)` is returned.
     ///
     /// Does not wait to acquire a lease, to do so see [`Client::acquire`].
     #[instrument(skip_all)]

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -59,6 +59,12 @@ impl Lease {
         drop(lease_v); // hold v-lock during deletion to ensure no race with `extend_lease`
         Ok(())
     }
+
+    /// Get the unique UUID identifier for this lease instance.
+    /// This UUID changes each time the lease is successfully extended.
+    pub async fn lease_v(&self) -> Uuid {
+        *self.key_lease_v.1.lock().await
+    }
 }
 
 fn start_periodically_extending(lease: &Lease) {

--- a/tests/usage.rs
+++ b/tests/usage.rs
@@ -5,6 +5,7 @@ use aws_sdk_dynamodb::types::{
     AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
 };
 use std::time::Duration;
+use time;
 use util::*;
 use uuid::Uuid;
 
@@ -22,7 +23,7 @@ async fn try_acquire() {
     // use 2 clients to avoid local locking / simulate distributed usage
     let client2 = dynamodb_lease::Client::builder()
         .table_name(lease_table)
-        .build_and_check_db(db_client)
+        .build_and_check_db(db_client.clone())
         .await
         .unwrap();
 
@@ -184,7 +185,7 @@ async fn release_try_acquire() {
     // use 2 clients to avoid local locking / simulate distributed usage
     let client2 = dynamodb_lease::Client::builder()
         .table_name(lease_table)
-        .build_and_check_db(db_client)
+        .build_and_check_db(db_client.clone())
         .await
         .unwrap();
 
@@ -202,12 +203,30 @@ async fn release_try_acquire() {
     // Release the lease and await deletion
     lease1.release().await.unwrap();
 
+    // Verify the item is actually deleted from dynamodb
+    let get_item_output = db_client
+        .get_item()
+        .table_name(lease_table)
+        .key(
+            "key",
+            aws_sdk_dynamodb::types::AttributeValue::S(lease_key.clone()),
+        )
+        .send()
+        .await
+        .expect("GetItem failed after release");
+
+    assert!(
+        get_item_output.item.is_none(),
+        "Item should have been deleted from DynamoDB after release"
+    );
+
     // now another client can immediately acquire
     client2
         .try_acquire(lease_key)
         .await
         .unwrap()
         .expect("failed to acquire after release");
+
     let _ = instance.stop().await;
 }
 
@@ -423,138 +442,56 @@ async fn init_should_check_ttl() {
 }
 
 #[tokio::test]
-async fn acquire_or_replace_expired_lease_replaces_after_grace_period() {
+async fn try_acquire_replaces_expired() {
     let lease_table = "test-locker-leases";
     let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
-    let ttl = Duration::from_secs(2);
-    let grace_period = Duration::from_secs(3);
-
-    let client1 = dynamodb_lease::Client::builder()
+    let client = dynamodb_lease::Client::builder()
         .table_name(lease_table)
-        .lease_ttl_seconds(ttl.as_secs() as u32)
-        .grace_period(grace_period)
         .build_and_check_db(db_client.clone())
         .await
         .unwrap();
-    let client2 = dynamodb_lease::Client::builder()
+
+    let lease_key = format!("try_acquire_replaces_expired:{}", Uuid::new_v4());
+    let expired_ts = time::OffsetDateTime::now_utc().unix_timestamp() - 1000;
+    let old_lease_v = Uuid::new_v4();
+
+    // Manually insert an expired lease item
+    db_client
+        .put_item()
         .table_name(lease_table)
-        .lease_ttl_seconds(ttl.as_secs() as u32)
-        .grace_period(grace_period)
-        .acquire_cooldown(Duration::from_millis(100)) // Speed up retry for test
-        .build_and_check_db(db_client)
+        .item(
+            "key",
+            aws_sdk_dynamodb::types::AttributeValue::S(lease_key.clone()),
+        )
+        .item(
+            "lease_expiry",
+            aws_sdk_dynamodb::types::AttributeValue::N(expired_ts.to_string()),
+        )
+        .item(
+            "lease_version",
+            aws_sdk_dynamodb::types::AttributeValue::S(old_lease_v.to_string()),
+        )
+        .send()
         .await
-        .unwrap();
+        .expect("Failed to insert expired lease item");
 
-    let lease_key = format!("replace_expired:{}", Uuid::new_v4());
-
-    // 1. Client 1 acquires the lease
-    let lease1 = client1.acquire(&lease_key).await.unwrap();
-    let lease1_version = lease1.lease_v().await;
-    println!("Client 1 acquired lease {}", lease1_version);
-
-    // 2. Drop lease1 immediately to stop the background extension task.
-    println!("Dropping lease1 to stop extensions");
-    drop(lease1);
-
-    // 3. Wait for TTL + Grace Period + buffer to ensure expiry and grace passed.
-    let wait_duration = ttl + grace_period + Duration::from_millis(500);
-    println!("Waiting for {:?} for expiry + grace period", wait_duration);
-    tokio::time::sleep(wait_duration).await;
-
-    // 4. Verify try_acquire still fails (item might exist due to TTL delay, but should be replaceable)
-    // Note: This check might be flaky depending on exact DynamoDB TTL timing.
-    // It's primarily checking our logic boundary, not DynamoDB's.
-    // assert!(
-    //     client2.try_acquire(&lease_key).await.unwrap().is_none(),
-    //     "try_acquire should fail even after grace period if item exists"
-    // );
-    // println!("Client 2 try_acquire correctly failed after grace period");
-
-    // 5. Client 2 should now be able to acquire the lease, replacing the expired one.
-    println!("Attempting acquire_or_replace_expired_lease");
-    let lease2 = tokio::time::timeout(
-        TEST_WAIT, // Use standard test wait, should be enough now
-        client2.acquire_or_replace_expired_lease(&lease_key),
-    )
-    .await
-    .expect("Client 2 timed out acquiring after grace period")
-    .expect("Client 2 failed to acquire after grace period");
-    let lease2_version = lease2.lease_v().await;
-    println!(
-        "Client 2 acquired lease {} after grace period",
-        lease2_version
+    // Try to acquire the lease - it should succeed by replacing the expired one
+    let lease = client.try_acquire(&lease_key).await.unwrap();
+    assert!(
+        lease.is_some(),
+        "Should have acquired the lease by replacing the expired item"
     );
 
-    // 6. Verify it's a *new* lease (different version)
-    assert_ne!(
-        lease1_version, lease2_version,
-        "Lease version should change after replacement"
-    );
-
-    // 7. Drop the new lease
-    drop(lease2);
-    let _ = instance.stop().await;
-}
-
-#[tokio::test]
-async fn acquire_or_replace_expired_lease_waits_like_acquire() {
-    let lease_table = "test-locker-leases";
-    let (db_client, instance) = get_test_db().await;
-    create_lease_table(lease_table, &db_client).await;
-
-    // Use clients with default TTL/grace period
-    let client1 = dynamodb_lease::Client::builder()
-        .table_name(lease_table)
-        .acquire_cooldown(Duration::from_millis(100)) // Speed up retry for test
-        .build_and_check_db(db_client.clone())
-        .await
-        .unwrap();
-    let client2 = dynamodb_lease::Client::builder()
-        .table_name(lease_table)
-        .acquire_cooldown(Duration::from_millis(100)) // Speed up retry for test
-        .build_and_check_db(db_client)
-        .await
-        .unwrap();
-
-    let lease_key = format!("replace_waits:{}", Uuid::new_v4());
-
-    // 1. Client 1 acquires the lease using normal acquire
-    let lease1 = client1.acquire(&lease_key).await.unwrap();
-    let lease1_v = lease1.lease_v().await;
-    println!("Client 1 acquired lease {}", lease1_v);
-
-    // 2. Spawn a task for Client 2 to acquire using acquire_or_replace_expired_lease
-    let key_clone = lease_key.clone();
-    let mut acquire_task = tokio::spawn(async move {
-        println!("Client 2 attempting acquire_or_replace...");
-        client2.acquire_or_replace_expired_lease(&key_clone).await
-    });
-
-    // 3. Check that Client 2's task blocks (doesn't complete immediately)
-    tokio::select! {
-        _ = tokio::time::sleep(Duration::from_secs(1)) => {
-            println!("Client 2 acquire task correctly blocked");
-        }
-        result = &mut acquire_task => {
-           panic!("Client 2 acquire completed unexpectedly: {:?}", result);
-        }
+    // Optionally: Verify the lease version changed
+    if let Some(acquired_lease) = lease {
+        assert_ne!(
+            acquired_lease.lease_v().await,
+            old_lease_v,
+            "Lease version should have been updated"
+        );
     }
 
-    // 4. Drop Client 1's lease
-    println!("Dropping Client 1's lease");
-    drop(lease1);
-
-    // 5. Client 2's task should now complete successfully
-    let lease2_result = tokio::time::timeout(TEST_WAIT, acquire_task)
-        .await
-        .expect("Client 2 acquire task timed out after lease1 dropped")
-        .expect("Client 2 acquire task panicked")
-        .expect("Client 2 failed to acquire lease after lease1 dropped");
-
-    let lease2_v = lease2_result.lease_v().await;
-    println!("Client 2 acquired lease {} successfully", lease2_v);
-    drop(lease2_result);
     let _ = instance.stop().await;
 }

--- a/tests/usage.rs
+++ b/tests/usage.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 #[tokio::test]
 async fn try_acquire() {
     let lease_table = "test-locker-leases";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
     let client = dynamodb_lease::Client::builder()
@@ -49,12 +49,13 @@ async fn try_acquire() {
             .and_then(|maybe_lease| maybe_lease.context("did not acquire"))
     })
     .await;
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn local_try_acquire() {
     let lease_table = "test-locker-leases";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
     let client = dynamodb_lease::Client::builder()
@@ -86,13 +87,14 @@ async fn local_try_acquire() {
             .and_then(|maybe_lease| maybe_lease.context("did not acquire"))
     })
     .await;
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 #[ignore = "slow"]
 async fn try_acquire_extend_past_ttl() {
     let lease_table = "test-locker-leases";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
     let client = dynamodb_lease::Client::builder()
@@ -126,12 +128,13 @@ async fn try_acquire_extend_past_ttl() {
         client2.try_acquire(&lease_key).await.unwrap().is_none(),
         "lease should have been extended"
     );
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn acquire() {
     let lease_table = "test-locker-leases";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
     let client = dynamodb_lease::Client::builder()
@@ -164,12 +167,13 @@ async fn acquire() {
         .await
         .expect("could not acquire after drop")
         .expect("failed to acquire");
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn release_try_acquire() {
     let lease_table = "test-locker-leases";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
     let client = dynamodb_lease::Client::builder()
@@ -204,12 +208,13 @@ async fn release_try_acquire() {
         .await
         .unwrap()
         .expect("failed to acquire after release");
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn local_acquire() {
     let lease_table = "test-locker-leases";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
     let client = dynamodb_lease::Client::builder()
@@ -235,12 +240,13 @@ async fn local_acquire() {
         .await
         .expect("could not acquire after drop")
         .expect("failed to acquire");
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn acquire_timeout() {
     let lease_table = "test-locker-leases";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
     create_lease_table(lease_table, &db_client).await;
 
     let client = dynamodb_lease::Client::builder()
@@ -277,11 +283,12 @@ async fn acquire_timeout() {
         .acquire_timeout(&lease_key, TEST_WAIT)
         .await
         .expect("failed to acquire");
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn init_should_check_table_exists() {
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
 
     let err = dynamodb_lease::Client::builder()
         .table_name("test-locker-leases-not-exists")
@@ -293,12 +300,13 @@ async fn init_should_check_table_exists() {
         "{}",
         err
     );
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn init_should_check_hash_key() {
     let table_name = "table-with-wrong-key";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
 
     let _ = db_client
         .create_table()
@@ -331,12 +339,13 @@ async fn init_should_check_hash_key() {
         "{}",
         err
     );
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn init_should_check_hash_key_type() {
     let table_name = "table-with-wrong-key-type";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
 
     let _ = db_client
         .create_table()
@@ -369,12 +378,13 @@ async fn init_should_check_hash_key_type() {
         "{}",
         err
     );
+    let _ = instance.stop().await;
 }
 
 #[tokio::test]
 async fn init_should_check_ttl() {
     let table_name = "table-with-without-ttl";
-    let db_client = localhost_dynamodb().await;
+    let (db_client, instance) = get_test_db().await;
 
     let _ = db_client
         .create_table()
@@ -409,4 +419,142 @@ async fn init_should_check_ttl() {
         "{}",
         err
     );
+    let _ = instance.stop().await;
+}
+
+#[tokio::test]
+async fn acquire_or_replace_expired_lease_replaces_after_grace_period() {
+    let lease_table = "test-locker-leases";
+    let (db_client, instance) = get_test_db().await;
+    create_lease_table(lease_table, &db_client).await;
+
+    let ttl = Duration::from_secs(2);
+    let grace_period = Duration::from_secs(3);
+
+    let client1 = dynamodb_lease::Client::builder()
+        .table_name(lease_table)
+        .lease_ttl_seconds(ttl.as_secs() as u32)
+        .grace_period(grace_period)
+        .build_and_check_db(db_client.clone())
+        .await
+        .unwrap();
+    let client2 = dynamodb_lease::Client::builder()
+        .table_name(lease_table)
+        .lease_ttl_seconds(ttl.as_secs() as u32)
+        .grace_period(grace_period)
+        .acquire_cooldown(Duration::from_millis(100)) // Speed up retry for test
+        .build_and_check_db(db_client)
+        .await
+        .unwrap();
+
+    let lease_key = format!("replace_expired:{}", Uuid::new_v4());
+
+    // 1. Client 1 acquires the lease
+    let lease1 = client1.acquire(&lease_key).await.unwrap();
+    let lease1_version = lease1.lease_v().await;
+    println!("Client 1 acquired lease {}", lease1_version);
+
+    // 2. Drop lease1 immediately to stop the background extension task.
+    println!("Dropping lease1 to stop extensions");
+    drop(lease1);
+
+    // 3. Wait for TTL + Grace Period + buffer to ensure expiry and grace passed.
+    let wait_duration = ttl + grace_period + Duration::from_millis(500);
+    println!("Waiting for {:?} for expiry + grace period", wait_duration);
+    tokio::time::sleep(wait_duration).await;
+
+    // 4. Verify try_acquire still fails (item might exist due to TTL delay, but should be replaceable)
+    // Note: This check might be flaky depending on exact DynamoDB TTL timing.
+    // It's primarily checking our logic boundary, not DynamoDB's.
+    // assert!(
+    //     client2.try_acquire(&lease_key).await.unwrap().is_none(),
+    //     "try_acquire should fail even after grace period if item exists"
+    // );
+    // println!("Client 2 try_acquire correctly failed after grace period");
+
+    // 5. Client 2 should now be able to acquire the lease, replacing the expired one.
+    println!("Attempting acquire_or_replace_expired_lease");
+    let lease2 = tokio::time::timeout(
+        TEST_WAIT, // Use standard test wait, should be enough now
+        client2.acquire_or_replace_expired_lease(&lease_key),
+    )
+    .await
+    .expect("Client 2 timed out acquiring after grace period")
+    .expect("Client 2 failed to acquire after grace period");
+    let lease2_version = lease2.lease_v().await;
+    println!(
+        "Client 2 acquired lease {} after grace period",
+        lease2_version
+    );
+
+    // 6. Verify it's a *new* lease (different version)
+    assert_ne!(
+        lease1_version, lease2_version,
+        "Lease version should change after replacement"
+    );
+
+    // 7. Drop the new lease
+    drop(lease2);
+    let _ = instance.stop().await;
+}
+
+#[tokio::test]
+async fn acquire_or_replace_expired_lease_waits_like_acquire() {
+    let lease_table = "test-locker-leases";
+    let (db_client, instance) = get_test_db().await;
+    create_lease_table(lease_table, &db_client).await;
+
+    // Use clients with default TTL/grace period
+    let client1 = dynamodb_lease::Client::builder()
+        .table_name(lease_table)
+        .acquire_cooldown(Duration::from_millis(100)) // Speed up retry for test
+        .build_and_check_db(db_client.clone())
+        .await
+        .unwrap();
+    let client2 = dynamodb_lease::Client::builder()
+        .table_name(lease_table)
+        .acquire_cooldown(Duration::from_millis(100)) // Speed up retry for test
+        .build_and_check_db(db_client)
+        .await
+        .unwrap();
+
+    let lease_key = format!("replace_waits:{}", Uuid::new_v4());
+
+    // 1. Client 1 acquires the lease using normal acquire
+    let lease1 = client1.acquire(&lease_key).await.unwrap();
+    let lease1_v = lease1.lease_v().await;
+    println!("Client 1 acquired lease {}", lease1_v);
+
+    // 2. Spawn a task for Client 2 to acquire using acquire_or_replace_expired_lease
+    let key_clone = lease_key.clone();
+    let mut acquire_task = tokio::spawn(async move {
+        println!("Client 2 attempting acquire_or_replace...");
+        client2.acquire_or_replace_expired_lease(&key_clone).await
+    });
+
+    // 3. Check that Client 2's task blocks (doesn't complete immediately)
+    tokio::select! {
+        _ = tokio::time::sleep(Duration::from_secs(1)) => {
+            println!("Client 2 acquire task correctly blocked");
+        }
+        result = &mut acquire_task => {
+           panic!("Client 2 acquire completed unexpectedly: {:?}", result);
+        }
+    }
+
+    // 4. Drop Client 1's lease
+    println!("Dropping Client 1's lease");
+    drop(lease1);
+
+    // 5. Client 2's task should now complete successfully
+    let lease2_result = tokio::time::timeout(TEST_WAIT, acquire_task)
+        .await
+        .expect("Client 2 acquire task timed out after lease1 dropped")
+        .expect("Client 2 acquire task panicked")
+        .expect("Client 2 failed to acquire lease after lease1 dropped");
+
+    let lease2_v = lease2_result.lease_v().await;
+    println!("Client 2 acquired lease {} successfully", lease2_v);
+    drop(lease2_result);
+    let _ = instance.stop().await;
 }


### PR DESCRIPTION
Introduces the ability for a client to acquire a lease even if an expired one exists, replacing it after a configurable grace period. This prevents leases from getting stuck indefinitely if the holder crashes without releasing.

- Adds `Lease::lease_v()` accessor.
- Replaces manual Docker setup script with `testcontainers` for managing DynamoDB Local in integration tests.
- Updates tests to use `testcontainers` and adds new tests for the replacement logic.
- Separates `ClientBuilder::build()` from `build_and_check_db()`.