### PR TITLE
Overwrite expired leases on acquire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased (0.22.1)
 * Add `Lease::release` fn.
+* Overwrite expired leases on acquire. This handles the case a crashed lease holder
+  has not cleaned up db state faster than waiting for db ttl cleanup.
 
 ## 0.22.0
 * Update _aws-sdk-dynamodb_ to `1.1`.


### PR DESCRIPTION
This handles the case a crashed lease holder has not cleaned up db state faster than waiting for db ttl cleanup.

ttl is technically sufficient already to handle this case, but according to docs can be [quite slow](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html).

> DynamoDB automatically deletes expired items within a few days of their expiration time

Resolves #3 