### PR TITLE
Add `Lease::is_healthy` fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased (0.22.1)
-* Add `Lease::release` fn.
 * Overwrite expired leases on acquire. This handles the case a crashed lease holder
   has not cleaned up db state faster than waiting for db ttl cleanup.
+* Add `Lease::is_healthy` fn.
+* Add `Lease::release` fn.
 
 ## 0.22.0
 * Update _aws-sdk-dynamodb_ to `1.1`.


### PR DESCRIPTION
> Returns `true` if the lease periodic extension task is still running.
> If lease extension fails, e.g. due to lost contact with the db, this will return `false`.

Resolves #8 